### PR TITLE
Add CLAUDE.md for Claude Code project briefing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,20 +1,24 @@
 # Android Architectural Standards
 
 ## 1. Layering Rules
+
 - **Domain Layer:** Must be pure Kotlin. No Android dependencies.
 - **Data Layer:** Use Repository pattern. Hide Room/Retrofit details.
 - **UI Layer:** Compose only. Access data via ViewModels, never Repositories.
 
 ## 2. Dependency Injection (Hilt)
+
 - Always use constructor injection.
 - Do not use `EntryPoint` unless absolutely necessary.
 
 ## 3. State & Concurrency
+
 - Use `StateFlow` for UI state.
 - Use `collectAsStateWithLifecycle()` in Composables.
 - Use `viewModelScope` for launching coroutines.
 
 ## 4. Testing Requirements
+
 - New ViewModels must have unit tests in `src/test`.
 - Use **Turbine** for Flow verification.
 - Use **Mockito** for mocking dependencies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,12 @@ Android weather app. Single screen. Clean Architecture (domain / data / presenta
 Package: `com.axehai.weatherscope` | Min SDK 29 | Kotlin + Jetpack Compose + Material3
 
 ## Stack
+
 - DI: Hilt | HTTP: Ktor + OkHttp | Storage: DataStore | Async: Coroutines + Flow
 - Serialization: kotlinx.serialization | Remote: Open-Meteo (forecast + geocoding)
 
 ## Architecture Rules
+
 - Domain layer is framework-free. No Android imports.
 - Repositories: interfaces in domain, implementations in data.
 - DTOs and storage models never leak into presentation.
@@ -16,20 +18,24 @@ Package: `com.axehai.weatherscope` | Min SDK 29 | Kotlin + Jetpack Compose + Mat
 - Inject coroutine dispatchers (never hardcode Dispatchers.IO/Main in testable code).
 
 ## v1 Scope (locked)
+
 One screen: featured weather card + highlights card + 7-day forecast card + search bar.
 Location sources: DEFAULT (New Delhi hardcoded), DEVICE (GPS), SEARCH (geocoding).
 No AQI. No multi-screen. No user accounts.
 
 ## Issue Board
+
 GitHub project: `axehai/weatherscope` — "WeatherScope — v1" (project #4, owner: axehai)
 Run `gh project item-list 4 --owner axehai --format json` for current status.
 
 ## How I'm Used Here
+
 - Issue scoping: what needs to be done, what to watch out for, cross-issue dependencies
 - Issue alignment: adjusting phrasing/scope to match practical dev order
 - Targeted help when stuck — not driving development
 
 ## Conventions
+
 - One issue = one PR, branch named `issue/<number>-short-desc`
 - Acceptance criteria in issues are the source of truth for done/not-done
 - Don't add comments, docstrings, or handling for things not in scope

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,4 +33,3 @@ Run `gh project item-list 4 --owner axehai --format json` for current status.
 - One issue = one PR, branch named `issue/<number>-short-desc`
 - Acceptance criteria in issues are the source of truth for done/not-done
 - Don't add comments, docstrings, or handling for things not in scope
-- Inject coroutine dispatchers (never hardcode Dispatchers.IO/Main in testable code)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# WeatherScope
+
+Android weather app. Single screen. Clean Architecture (domain / data / presentation).
+Package: `com.axehai.weatherscope` | Min SDK 29 | Kotlin + Jetpack Compose + Material3
+
+## Stack
+- DI: Hilt | HTTP: Ktor + OkHttp | Storage: DataStore | Async: Coroutines + Flow
+- Serialization: kotlinx.serialization | Remote: Open-Meteo (forecast + geocoding)
+
+## Architecture Rules
+- Domain layer is framework-free. No Android imports.
+- Repositories: interfaces in domain, implementations in data.
+- DTOs and storage models never leak into presentation.
+- `Resource` sealed class is the standard async result wrapper.
+- Use cases are the primary unit-test targets.
+- Inject coroutine dispatchers (never hardcode Dispatchers.IO/Main in testable code).
+
+## v1 Scope (locked)
+One screen: featured weather card + highlights card + 7-day forecast card + search bar.
+Location sources: DEFAULT (New Delhi hardcoded), DEVICE (GPS), SEARCH (geocoding).
+No AQI. No multi-screen. No user accounts.
+
+## Issue Board
+GitHub project: `axehai/weatherscope` — "WeatherScope — v1" (project #4, owner: axehai)
+Run `gh project item-list 4 --owner axehai --format json` for current status.
+
+## How I'm Used Here
+- Issue scoping: what needs to be done, what to watch out for, cross-issue dependencies
+- Issue alignment: adjusting phrasing/scope to match practical dev order
+- Targeted help when stuck — not driving development
+
+## Conventions
+- One issue = one PR, branch named `issue/<number>-short-desc`
+- Acceptance criteria in issues are the source of truth for done/not-done
+- Don't add comments, docstrings, or handling for things not in scope
+- Inject coroutine dispatchers (never hardcode Dispatchers.IO/Main in testable code)

--- a/README.MD
+++ b/README.MD
@@ -110,7 +110,6 @@ Each feature is developed by:
 2. Writing unit tests for the use case
 3. Implementing supporting services/providers
 
-
 Tests validate:
 
 * domain behavior


### PR DESCRIPTION
closes #36

## Summary
- Adds `CLAUDE.md` at project root to brief Claude Code at the start of every session
- Covers stack, architecture rules, v1 scope, conventions, and how to fetch live issue status
- Stays evergreen — no hardcoded issue statuses, uses `gh` CLI for live data

## Test plan
- [x] File is present at project root
- [ ] Content is consistent with `.coderabbit.yaml` architecture rules
- [ ] No hardcoded issue statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation defining v1 app scope: single-screen Compose/Material3 UI with a featured weather card, highlights card, 7-day forecast, and search bar.
  * Clarified supported location sources: default (New Delhi), device GPS, and search-based geocoding; excluded AQI, multi-screen flows, and user accounts.
  * Included development conventions and contribution workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->